### PR TITLE
Try to add sha256 to fingerprints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            - "bc:0c:3a:3a:6d:ce:dd:b5:19:40:15:1b:6e:95:33:a0"
+            - "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"
 
       - run:
           name: Release


### PR DESCRIPTION
Attempt to try to unstuck the CircleCI which is being stuck in the
following process:

```
RSA key fingerprint is
SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)
```